### PR TITLE
Add census authorization handler

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,6 +17,15 @@
     "AWS_SECRET_ACCESS_KEY": {
       "required": true
     },
+    "CENSUS_PASSWORD": {
+      "required": true
+    },
+    "CENSUS_URL": {
+      "required": true
+    },
+    "CENSUS_USERNAME": {
+      "required": true
+    },
     "HERE_APP_ID": {
       "required": false
     },
@@ -26,7 +35,6 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
-
     "SECRET_KEY_BASE": {
       "description": "A secret used by Rails to identify sessions",
       "generator": "secret"

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -107,7 +107,7 @@ EOS
   end
 
   def over_16
-    errors.add(:date_of_birth, I18n.t("census_authorization_handler.age_under_18")) unless age && age >= 16
+    errors.add(:date_of_birth, I18n.t("census_authorization_handler.age_under_16")) unless age && age >= 16
   end
 
   def age

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -9,13 +9,11 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
 
   attribute :document_number, String
   attribute :document_type, Symbol
-  attribute :scope_id, Integer
   attribute :date_of_birth, Date
 
   validates :date_of_birth, presence: true
   validates :document_type, inclusion: { in: %i(dni nie passport community_dni) }, presence: true
   validates :document_number, format: { with: /\A[A-z0-9]*\z/ }, presence: true
-  validates :scope_id, presence: true
 
   validate :document_type_valid
   validate :over_16
@@ -36,14 +34,6 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
     end
 
     instance
-  end
-
-  def metadata
-    super.merge(scope: scope.name)
-  end
-
-  def scope
-    Decidim::Scope.find(scope_id)
   end
 
   def census_document_types

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+# Checks the authorization against the census for Terrassa.
+require "digest/md5"
+
+# This class performs a check against the official census database in order
+# to verify the citizen's residence.
+class CensusAuthorizationHandler < Decidim::AuthorizationHandler
+  include ActionView::Helpers::SanitizeHelper
+
+  attribute :document_number, String
+  attribute :document_type, Symbol
+  attribute :scope_id, Integer
+  attribute :date_of_birth, Date
+
+  validates :date_of_birth, presence: true
+  validates :document_type, inclusion: { in: %i(dni nie passport community_dni) }, presence: true
+  validates :document_number, format: { with: /\A[A-z0-9]*\z/ }, presence: true
+  validates :scope_id, presence: true
+
+  validate :document_type_valid
+  validate :over_16
+
+  def self.from_params(params, additional_params = {})
+    instance = super(params, additional_params)
+
+    params_hash = hash_from(params)
+
+    if params_hash["date_of_birth(1i)"]
+      date = Date.civil(
+        params["date_of_birth(1i)"].to_i,
+        params["date_of_birth(2i)"].to_i,
+        params["date_of_birth(3i)"].to_i
+      )
+
+      instance.date_of_birth = date
+    end
+
+    instance
+  end
+
+  def metadata
+    super.merge(scope: scope.name)
+  end
+
+  def scope
+    Decidim::Scope.find(scope_id)
+  end
+
+  def census_document_types
+    %i(dni nie passport community_dni).map do |type|
+      [I18n.t(type, scope: "decidim.census_authorization_handler.document_types"), type]
+    end
+  end
+
+  def unique_id
+    Digest::MD5.hexdigest(
+      "#{document_number}-#{Rails.application.secrets.secret_key_base}"
+    )
+  end
+
+  private
+
+  def sanitized_document_type
+    case document_type&.to_sym
+    when :dni
+      1
+    when :passport
+      2
+    when :nie
+      3
+    when :community_dni
+      4
+    end
+  end
+
+  def sanitized_date_of_birth
+    @sanitized_date_of_birth ||= date_of_birth&.strftime("%d-%m-%Y")
+  end
+
+  def document_type_valid
+    return nil if response.blank?
+
+    errors.add(:document_number, I18n.t("census_authorization_handler.invalid_document")) unless response.xpath("//existeix").text == "true"
+  end
+
+  def response
+    return nil if document_number.blank? ||
+                  document_type.blank? ||
+                  date_of_birth.blank?
+
+    return @response if defined?(@response)
+
+    response ||= Faraday.post Rails.application.secrets.census_url do |request|
+      request.headers["Content-Type"] = "text/xml"
+      request.body = request_body
+    end
+
+    @response ||= Nokogiri::XML(response.body).remove_namespaces!
+  end
+
+
+  def request_body
+    @request_body ||= <<EOS
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:pad="http://padro.serveis.terrassa.cat/">
+  <soapenv:Header/>
+  <soapenv:Body>
+    <pad:existeix>
+    <tipusDocument>#{sanitized_document_type}</tipusDocument>
+      <numDocument>#{sanitize document_number&.upcase}</numDocument>
+      <dataNaixement>#{sanitized_date_of_birth}</dataNaixement>
+      <usuari>#{census_username}</usuari>
+      <clau>#{census_password}</clau>
+    </pad:existeix>
+  </soapenv:Body>
+</soapenv:Envelope>
+EOS
+  end
+
+  def over_16
+    errors.add(:date_of_birth, I18n.t("census_authorization_handler.age_under_18")) unless age && age >= 16
+  end
+
+  def age
+    return nil if date_of_birth.blank?
+
+    now = Date.current
+    extra_year = (now.month > date_of_birth.month) || (
+      now.month == date_of_birth.month && now.day >= date_of_birth.day
+    )
+
+    now.year - date_of_birth.year - (extra_year ? 0 : 1)
+  end
+
+  def census_username
+    Rails.application.secrets.census_username
+  end
+
+  def census_password
+    Rails.application.secrets.census_password
+  end
+end

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -10,10 +10,6 @@
   <%= form.date_select :date_of_birth, start_year: 1900, end_year: 16.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
 </div>
 
-<div class="field">
-  <%= form.collection_select :scope_id, current_organization.scopes, :id, :name, prompt: t(".scope_prompt") %>
-</div>
-
 <%= form.hidden_field :handler_name %>
 
 <div class="actions">

--- a/app/views/census_authorization/_form.html.erb
+++ b/app/views/census_authorization/_form.html.erb
@@ -1,0 +1,21 @@
+<div class="field">
+  <%= form.select :document_type, handler.census_document_types, prompt: true %>
+</div>
+
+<div class="field">
+  <%= form.text_field :document_number %>
+</div>
+
+<div class="field date">
+  <%= form.date_select :date_of_birth, start_year: 1900, end_year: 16.years.ago.year, default: 35.years.ago, prompt: { day: t(".date_select.day"), month: t(".date_select.month"), year: t(".date_select.year") } %>
+</div>
+
+<div class="field">
+  <%= form.collection_select :scope_id, current_organization.scopes, :id, :name, prompt: t(".scope_prompt") %>
+</div>
+
+<%= form.hidden_field :handler_name %>
+
+<div class="actions">
+  <%= form.submit t("authorize", scope: "decidim.authorizations.new"), class: "button expanded" %>
+</div>

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
 Decidim.configure do |config|
-  config.application_name = "My Application Name"
+  config.application_name = "Decidim Terrassa"
   config.mailer_sender    = "change-me@domain.org"
-  config.authorization_handlers = [ExampleAuthorizationHandler]
+  config.authorization_handlers = [CensusAuthorizationHandler]
 
   # Uncomment this lines to set your preferred locales
   config.available_locales = %i{ca es}

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,0 +1,33 @@
+ca:
+  census_authorization_handler:
+    invalid_document: Número de document incorrecte
+  activemodel:
+    attributes:
+      census_authorization_handler:
+        document_number: Número de document
+        document_type: Tipus de document
+        postal_code: Codi postal
+        date_of_birth: Data de naixement
+  census_authorization:
+    form:
+      scope_prompt: Si us plau, selecciona el teu districte
+      date_select:
+        day: "Dia"
+        month: "Mes"
+        year: "Any"
+  decidim:
+    authorization_handlers:
+      census_authorization_handler:
+        fields:
+          document_number: Número de document
+          document_type: Tipus de document
+          postal_code: Codi postal
+          date_of_birth: Data de naixement
+          scope: Districte
+        name: El padró
+    census_authorization_handler:
+      document_types:
+        dni: DNI
+        nie: NIE
+        passport: Passaport
+        community_dni: DNI comunitari

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -1,5 +1,6 @@
 ca:
   census_authorization_handler:
+    age_under_16: Has de ser major de 16 anys per verificar-te
     invalid_document: Número de document incorrecte
   activemodel:
     attributes:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,33 @@
+es:
+  census_authorization_handler:
+    invalid_document: Número de documento incorrecto
+  activemodel:
+    attributes:
+      census_authorization_handler:
+        document_number: Número de documento
+        document_type: Tipo de documento
+        postal_code: Código postal
+        date_of_birth: Fecha de nacimiento
+  census_authorization:
+    form:
+      scope_prompt: Por favor, selecciona tu distrito
+      date_select:
+        day: "Día"
+        month: "Mes"
+        year: "Año"
+  decidim:
+    authorization_handlers:
+      census_authorization_handler:
+        name: El padrón
+        fields:
+          document_number: Número de documento
+          document_type: Tipo de documento
+          postal_code: Código postal
+          date_of_birth: Fecha de nacimiento
+          scope_id: Distrito
+    census_authorization_handler:
+      document_types:
+        dni: DNI
+        nie: NIE
+        passport: Pasaporte
+        community_dni: DNI comunitario

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,6 @@
 es:
   census_authorization_handler:
+    age_under_16: Tienes que ser mayor de 16 años para verificarte
     invalid_document: Número de documento incorrecto
   activemodel:
     attributes:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,9 @@ default: &default
   sentry_enabled: false
   aws_access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  census_url: <%= ENV["CENSUS_URL"] %>
+  census_username: <%= ENV["CENSUS_USERNAME"] %>
+  census_password: <%= ENV["CENSUS_PASSWORD"] %>
   omniauth:
     facebook:
       # It must be a boolean. Remember ENV variables doesn't support booleans.

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -9,19 +9,12 @@ describe CensusAuthorizationHandler do
   let(:document_number) { "12345678A" }
   let(:document_type) { :nie }
   let(:date_of_birth) { Date.civil(1987, 9, 17) }
-  let(:scope_id) { 123 }
-  let(:scope) { double(name: "Ciutat Vella") }
   let(:params) do
     {
       document_number: document_number,
       document_type: document_type,
-      scope_id: scope_id,
       date_of_birth: date_of_birth
     }
-  end
-
-  before do
-    allow(Decidim::Scope).to receive(:find).and_return(scope)
   end
 
   it_behaves_like "an authorization handler"
@@ -146,12 +139,6 @@ describe CensusAuthorizationHandler do
       end
 
       it { is_expected.to_not be_valid }
-    end
-  end
-
-  describe "metadata" do
-    it "includes the scope" do
-      expect(subject.metadata).to include(scope: "Ciutat Vella")
     end
   end
 end

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -1,0 +1,157 @@
+# coding: utf-8
+# frozen_string_literal: true
+require "rails_helper"
+require "decidim/dev/test/authorization_shared_examples"
+
+describe CensusAuthorizationHandler do
+  let(:subject) { handler }
+  let(:handler) { described_class.from_params(params) }
+  let(:document_number) { "12345678A" }
+  let(:document_type) { :nie }
+  let(:date_of_birth) { Date.civil(1987, 9, 17) }
+  let(:scope_id) { 123 }
+  let(:scope) { double(name: "Ciutat Vella") }
+  let(:params) do
+    {
+      document_number: document_number,
+      document_type: document_type,
+      scope_id: scope_id,
+      date_of_birth: date_of_birth
+    }
+  end
+
+  before do
+    allow(Decidim::Scope).to receive(:find).and_return(scope)
+  end
+
+  it_behaves_like "an authorization handler"
+
+  context "with a valid response" do
+    before do
+      allow(handler)
+        .to receive(:response)
+        .and_return(Nokogiri::XML("<existeix>true</existeix>").remove_namespaces!)
+    end
+
+    describe "document_number" do
+      context "when it isn't present" do
+        let(:document_number) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "with an invalid format" do
+        let(:document_number) { "(╯°□°）╯︵ ┻━┻" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe "document_type" do
+      context "when it isn't present" do
+        let(:document_type) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when it has a weird value" do
+        let(:document_type) { :driver_license }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+
+    describe "date_of_birth" do
+      context "when it isn't present" do
+        let(:date_of_birth) { nil }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when it's under 16" do
+        let(:date_of_birth) { 15.years.ago }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "when data from a date field is provided" do
+        let(:params) do
+          {
+            "date_of_birth(1i)" => "2010",
+            "date_of_birth(2i)" => "8",
+            "date_of_birth(3i)" => "16"
+          }
+        end
+
+        let(:date_of_birth) { nil }
+
+        it "correctly parses the date" do
+          expect(subject.date_of_birth.year).to eq(2010)
+          expect(subject.date_of_birth.month).to eq(8)
+          expect(subject.date_of_birth.day).to eq(16)
+        end
+      end
+    end
+
+    context "when everything is fine" do
+      it { is_expected.to be_valid }
+    end
+  end
+
+  context "unique_id" do
+    it "generates a different ID for a different document number" do
+      handler.document_number = "ABC123"
+      unique_id1 = handler.unique_id
+
+      handler.document_number = "XYZ456"
+      unique_id2 = handler.unique_id
+
+      expect(unique_id1).to_not eq(unique_id2)
+    end
+
+    it "generates the same ID for the same document number" do
+      handler.document_number = "ABC123"
+      unique_id1 = handler.unique_id
+
+      handler.document_number = "ABC123"
+      unique_id2 = handler.unique_id
+
+      expect(unique_id1).to eq(unique_id2)
+    end
+
+    it "hashes the document number" do
+      handler.document_number = "ABC123"
+      unique_id = handler.unique_id
+
+      expect(unique_id).to_not include(handler.document_number)
+    end
+  end
+
+  context "with an invalid response" do
+    context "with a malformed response" do
+      before do
+        allow(handler)
+          .to receive(:response)
+          .and_return(Nokogiri::XML("Messed up response!").remove_namespaces!)
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "with an invalid response code" do
+      before do
+        allow(handler)
+          .to receive(:response)
+          .and_return(Nokogiri::XML("<codiRetorn>02</codiRetorn>").remove_namespaces!)
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+  end
+
+  describe "metadata" do
+    it "includes the scope" do
+      expect(subject.metadata).to include(scope: "Ciutat Vella")
+    end
+  end
+end


### PR DESCRIPTION
Adds authorization via the census of the town. Needs some real testing via the review app, and some environment configuration set:

- `CENSUS_URL`
- `CENSUS_USERNAME`
- `CENSUS_PASSWORD`