### PR TITLE
Remove sign in census authorization

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # frozen_string_literal: true
-require "decidim/terrassa"
 
 Decidim.configure do |config|
   config.application_name = "Participa a Terrassa"

--- a/lib/decidim/terrassa.rb
+++ b/lib/decidim/terrassa.rb
@@ -1,1 +1,0 @@
-require "decidim/terrassa/decidim_registration_patch"

--- a/lib/decidim/terrassa/decidim_registration_patch.rb
+++ b/lib/decidim/terrassa/decidim_registration_patch.rb
@@ -1,5 +1,0 @@
-Decidim::Devise::SessionsController.class_eval do
-  def after_sign_in_path_for(user)
-    super
-  end
-end


### PR DESCRIPTION
#### :tophat: What? Why?
Remove sign in census circumvention, as census authorization is being used now.

#### :pushpin: Related Issues
- Related to #1897

#### :clipboard: Subtasks
*None*

### :camera: Screenshots (optional)
*None*
