### PR TITLE
Age authorization handler

### DIFF
--- a/app/services/age_authorization_handler.rb
+++ b/app/services/age_authorization_handler.rb
@@ -1,0 +1,58 @@
+
+class AgeAuthorizationHandler < Decidim::Verifications::DefaultActionAuthorizer
+  def missing_fields
+    @missing_fields ||= (valid_metadata? ? [] : [:birthdate])
+  end
+
+  def unmatched_fields
+    @unmatched_fields ||= set_unmatched_fields
+  end
+
+  private
+
+  def set_unmatched_fields
+    errors = []
+    errors << :birthdate unless valid_age?
+    errors
+  end
+
+  def valid_metadata?
+    return unless authorization
+
+    !authorization.metadata['birthdate'].nil?
+  end
+
+  def valid_age?
+    return age_between?(age, max_age) if options['max_age'].present?
+    
+    age <= user_age
+  end
+
+  def birthdate
+    authorization.metadata['birthdate'].to_date
+  end
+
+  def age
+    options['age'].to_i
+  end
+
+  def max_age
+    options['max_age'].to_i
+  end
+
+  def age_between?(age, max_age)
+    (age..max_age).cover?(user_age)
+  end
+
+  def user_age
+    return nil if birthdate.blank?
+
+    now = Date.current
+    extra_year = (now.month > birthdate.month) || (
+      now.month == birthdate.month && now.day >= birthdate.day
+    )
+
+    now.year - birthdate.year - (extra_year ? 0 : 1)
+  end
+end
+

--- a/app/services/age_authorization_handler.rb
+++ b/app/services/age_authorization_handler.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 class AgeAuthorizationHandler < Decidim::Verifications::DefaultActionAuthorizer
   def missing_fields
     @missing_fields ||= (valid_metadata? ? [] : [:birthdate])

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -32,9 +32,12 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   end
 
   def metadata
-    super.merge(district: district) if district.present?
+    { 
+      birthdate: sanitized_date_of_birth, 
+      district: (district if district.present?)
+    }.compact 
   end
-
+  
   private
 
   def district

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -34,8 +34,11 @@ end
 
 Decidim::Verifications.register_workflow(:census_authorization_handler) do |auth|
   auth.form = "CensusAuthorizationHandler"
+  auth.action_authorizer = 'AgeAuthorizationHandler'
   auth.options do |options|
     options.attribute :district, type: :string, required: false
+    options.attribute :age, type: :string, required: false
+    options.attribute :max_age, type: :string, required: false
   end
 end
 

--- a/config/locales/ca.yml
+++ b/config/locales/ca.yml
@@ -29,6 +29,8 @@ ca:
       census_authorization_handler:
         explanation: Verifica't amb el padró
         fields:
+          age: Edat mínima
+          max_age: Edat màxima
           document_number: Número de document
           document_type: Tipus de document
           postal_code: Codi postal

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -30,6 +30,8 @@ es:
         name: El padrón
         explanation: Verifícate con el padrón
         fields:
+          age: Edad mínima
+          max_age: Edad máxima
           document_number: Número de documento
           document_type: Tipo de documento
           postal_code: Código postal

--- a/spec/services/age_authorization_handler_spec.rb
+++ b/spec/services/age_authorization_handler_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe AgeAuthorizationHandler do
+  let(:authorizer_class) { AgeAuthorizationHandler }
+  let(:component) { double('component') }
+  let(:resource) { double('resource', component: true) }
+
+  it 'authorizes with age metadata' do
+    authorizer = authorizer_class.new(authorization_for('1970/11/21'), { age: '20' }, component, resource)
+    expect(authorizer.authorize).to include(:ok)
+  end
+
+  it 'does not authorize the user if the authorization is not present' do
+    authorizer_without_authorization = authorizer_class.new(nil, { age: nil }, component, resource)
+    expect(authorizer_without_authorization.authorize).to include(:missing)
+  end
+
+  describe 'when max_age is present' do
+    it 'authorizes if is older that :age and yonger that :max_age' do
+      birthdate = 21.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:ok)
+    end
+
+    it 'authorizes if is older that :age and equal that :max_age' do
+      birthdate = 22.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:ok)
+    end
+
+    it 'not authorizes if is older of :max_age' do
+      birthdate = 23.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:unauthorized)
+    end
+
+    it 'not authorizes if is younger of :age' do
+      birthdate = 19.years.ago.strftime('%Y/%m/%d')
+      authorizer = authorizer_class.new(authorization_for(birthdate), { 'age' => '20', 'max_age' => '22' }, component, resource)
+      expect(authorizer.authorize).to include(:unauthorized)
+    end
+  end
+
+  def authorization_for(date)
+    OpenStruct.new(metadata: { 'birthdate' => date },
+                   granted?: true)
+  end
+end

--- a/spec/services/census_authorization_handler_spec.rb
+++ b/spec/services/census_authorization_handler_spec.rb
@@ -95,7 +95,7 @@ describe CensusAuthorizationHandler do
 
     describe "district" do
       it "parses it from the response" do
-        expect(subject.metadata).to eq(district: "4")
+        expect(subject.metadata).to eq({:birthdate=>"17-09-1987", :district=>"4"})
       end
     end
 


### PR DESCRIPTION
#### :tophat: What? Why?
Adds min and max age constraints to census authorization.

#### :pushpin: Related Issues
- Related to [Minimum age participation](https://app.asana.com/0/1163927362550361/1163927362550364)

#### :clipboard: Subtasks
- [x] Adds tests
- [x] Adds `age` and `max_age` options to custom workflow
- [x] Updates locales
- [x] Adds `age_authorization_handler`



